### PR TITLE
Script to automatically delete old data

### DIFF
--- a/Jobs/deleteolddata.php
+++ b/Jobs/deleteolddata.php
@@ -1,11 +1,4 @@
 <?php
-// // cleanup_script.php
-
-// // Your PHP logic goes here
-// $message = "Cron job executed successfully!\n";
-// $currentDateTime = date('Y-m-d H:i:s');
-// echo 'PROJECT -> '. $currentDateTime . ': ' .$message;
-
 /**
 *  Cron Example:
 *  This script must be executed at a specific time to be enabled
@@ -13,7 +6,7 @@
 
 *  Each * correspods to Minute Hour Day_Of_Month Month Day_Of_Week, respectively
 
-*  /usr/bin/env php -f                                  -> the path to php (run "which php" to know where it is)
+*  /usr/bin/env php -f                                  -> the path to php (run "which php" to know what it is)
 *  ${WWW_DIR}/librebooking/Jobs/sendmissedcheckin.php   -> the path to this script
 */
 define('ROOT_DIR', dirname(__FILE__) . '/../');
@@ -22,49 +15,55 @@ require_once(ROOT_DIR . 'Jobs/JobCop.php');
 
 Log::Debug('Running deleteolddata.php');
 
-$configFilePath = '/opt/lampp/htdocs/librebooking/app/config/config.php';
-
-if (file_exists($configFilePath)) { echo ("Ficheiro existe!"); } 
-
 JobCop::EnsureCommandLine();
 
 try {
+    //Delete announcements, blackouts and reservations older than $deleteBefore (years -> -2 = 2+ years older)
+    $deleteBefore = Date::Now()->AddYears(-2);
+
     //ANNOUNCEMENTS
-    $getAnnouncements = GetAnnoucementsIdsToDeleteQuery();
-    echo $getAnnouncements;
+    $getAnnouncements = GetAnnoucementsIdsToDeleteQuery($deleteBefore);
     $reader = ServiceLocator::GetDatabase()->Query($getAnnouncements);
     Log::Debug('Getting %s old announcements', $reader->NumRows());
     while ($row = $reader->GetRow()) {
         $annoucementId = $row[ColumnNames::ANNOUNCEMENT_ID];
-        Log::Debug('Deleting announcement with id %s', $annoucementId);
-        DeleteAnnouncementsQuery($AnnoucementId);
+        DeleteAnnouncementsQuery($annoucementId);
     }
     $reader->Free();
+    echo "ANUNCIOS APAGADOS\n";
 
     //BLACKOUTS
-    $getBlackouts = GetBlackoutsIdsToDeleteQuery();
-    echo $getBlackouts;
+    $getBlackouts = GetBlackoutsIdsToDeleteQuery($deleteBefore);
     $reader = ServiceLocator::GetDatabase()->Query($getBlackouts);
     Log::Debug('Getting %s old blackouts', $reader->NumRows());
     while ($row = $reader->GetRow()) {
         $blackoutId = $row[ColumnNames::BLACKOUT_SERIES_ID];
-        Log::Debug('Deleting blackout with id %s', $blackoutId);
-        DeleteBlackoutsQuery($BlackoutId);      
+        DeleteBlackoutsQuery($blackoutId);      
     }
     $reader->Free();
+    echo "BLACKOUTS APAGADOS\n";
 
     //RESERVATIONS
-    $getReservations = GetReservationsIdsToDeleteQuery();
-    echo $getReservations;
+    $getReservations = GetReservationsIdsToDeleteQuery($deleteBefore);
     $reader = ServiceLocator::GetDatabase()->Query($getReservations);
     Log::Debug('Getting %s old reservations', $reader->NumRows());
     while ($row = $reader->GetRow()) {
         $reservationId = $row[ColumnNames::RESERVATION_SERIES_ID];
-        Log::Debug('Deleting reservation with id %s', $reservationId);
-        DeleteReservationsQuery($ReservationId);
+
+        //RESERVATION USERS
+        $getReservationUsers = GetReservationUsersToDelete($reservationId);
+        $auxReader = ServiceLocator::GetDatabase()->Query($getReservationUsers);
+        while ($auxRow = $auxReader->GetRow()){
+            $reservationUser = $auxRow[ColumnNames::RESERVATION_INSTANCE_ID];
+            DeleteReservationUsersQuery($reservationUser);
+        }
+
+        $auxReader->Free();
+        echo "USER APAGADO\n";
+        DeleteReservationsQuery($reservationId);
     }
     $reader->Free();
-    
+    echo "RESERVAS APAGADAS\n";
 
 } catch (Exception $ex){
     Log::Error('Error running deleteolddata.php: %s', $ex);
@@ -72,31 +71,10 @@ try {
 
 Log::Debug('Finished running deleteolddata.php');
 
+//GET INSTANCES FUNCTIONS
 
-function GetReservationsIdsToDeleteQuery() {
-    
-    $deleteBefore = Date::Now()->AddYears(-1);
-
-    $reservationIds = new AdHocCommand(
-        "   SELECT reservation_series.series_id
-            FROM reservation_series
-            LEFT JOIN reservation_instances 
-            ON reservation_instances.series_id = reservation_series.series_id
-            WHERE reservation_series.repeat_type = 'none' AND end_date < '{$deleteBefore}'
-            
-            UNION
-            
-            SELECT series_id
-            FROM reservation_series
-            WHERE SUBSTRING_INDEX(SUBSTRING_INDEX(repeat_options, '|', -1), '=', -1) < '{$deleteBefore}' AND repeat_options != ''"
-    );
-
-    return $reservationIds;
-}
-
-function GetAnnoucementsIdsToDeleteQuery(){
-
-    $deleteBefore = Date::Now()->AddYears(-1);
+//          ->  ANNOUNCEMENTS
+function GetAnnoucementsIdsToDeleteQuery($deleteBefore){
 
     $annoucementsIds = new AdHocCommand(
         "   SELECT announcementid
@@ -107,9 +85,8 @@ function GetAnnoucementsIdsToDeleteQuery(){
     return $annoucementsIds;
 }
 
-function GetBlackoutsIdsToDeleteQuery(){
-
-    $deleteBefore = Date::Now()->AddYears(-1);
+//          ->  BLACKOUTS
+function GetBlackoutsIdsToDeleteQuery($deleteBefore){
 
     $blackoutsIds = new AdHocCommand(
         "   SELECT blackout_series_id
@@ -128,59 +105,43 @@ function GetBlackoutsIdsToDeleteQuery(){
     return $blackoutsIds;
 }
 
-function DeleteReservationsQuery($reservationId){
-    $deleteReservationAcessories = new AdHocCommand(
-        "DELETE FROM reservation_acessories
-        WHERE series_id = '{$reservationId}'"
+//          ->  RESERVATION USERS
+function GetReservationUsersToDelete($reservationSeriesId){ 
+    $reservationInstance = new AdHocCommand(
+        "   SELECT reservation_instance_id
+            FROM reservation_instances
+            WHERE series_id = '{$reservationSeriesId}'"
     );
-    ServiceLocator::GetDatabase()->Execute($deleteReservationAcessories);
-
-    $deleteReservationFiles = new AdHocCommand(
-        "DELETE FROM reservation_files
-        WHERE series_id = '{$reservationId}'"
-    );
-    ServiceLocator::GetDatabase()->Execute($deleteReservationFiles);
-
-    $deleteReservationGuests = new AdHocCommand(
-        "DELETE FROM reservation_guests
-        WHERE series_id = '{$reservationId}'"
-    );
-    ServiceLocator::GetDatabase()->Execute($deleteReservationGuests);
-
-    $deleteReservationReminders = new AdHocCommand(
-        "DELETE FROM reservation_reminders 
-        WHERE series_id = '{$reservationId}'"
-    );
-    ServiceLocator::GetDatabase()->Execute($deleteReservationReminders);
-
-    $deleteReservationResources = new AdHocCommand(
-        "DELETE FROM reservation_resources
-        WHERE series_id = '{$reservationId}'"
-    );
-    ServiceLocator::GetDatabase()->Execute($deleteReservationResources);
-
-    $deleteReservationUsers = new AdHocCommand(
-        "DELETE FROM reservation_users
-        WHERE series_id = '{$reservationId}'"
-    );
-    ServiceLocator::GetDatabase()->Execute($deleteReservationUsers);
-
-    $deleteReservationInstances = new AdHocCommand(
-        "DELETE FROM reservation_instances
-        WHERE series_id = '{$reservationId}'"
-    );
-    ServiceLocator::GetDatabase()->Execute($deleteReservationInstances);
-
-    $deleteReservationSeries = new AdHocCommand(
-        "DELETE FROM reservation_series
-        WHERE series_id = '{$reservationId}'"
-    );    
-    ServiceLocator::GetDatabase()->Execute($deleteReservationSeries);
-
-    Log::Debug('Reservation with id %s deleted', $reservationId);
+    return $reservationInstance;
 }
 
+//          -> RESERVATIONS
+function GetReservationsIdsToDeleteQuery($deleteBefore) {
+
+    $reservationIds = new AdHocCommand(
+        "   SELECT reservation_series.series_id
+            FROM reservation_series
+            LEFT JOIN reservation_instances 
+            ON reservation_instances.series_id = reservation_series.series_id
+            WHERE reservation_series.repeat_type = 'none' AND end_date < '{$deleteBefore}'
+            
+            UNION
+            
+            SELECT series_id
+            FROM reservation_series
+            WHERE SUBSTRING_INDEX(SUBSTRING_INDEX(repeat_options, '|', -1), '=', -1) < '{$deleteBefore}' AND repeat_options != ''"
+    );
+
+    return $reservationIds;
+}
+
+
+//DELETE INSTANCES FUNCTIONS
+
+//          ->  ANNOUNCEMENTS
 function DeleteAnnouncementsQuery($announcementid){
+    Log::Debug('Deleting announcement with id %s', $announcementid);
+
     $deleteGroupAnnouncements = new AdHocCommand(
         "   DELETE FROM announcement_groups 
             WHERE announcementid = '{$announcementid}'"
@@ -202,7 +163,10 @@ function DeleteAnnouncementsQuery($announcementid){
     Log::Debug('Announcement with id %s deleted', $announcementid);
 }
 
+//          ->    BLACKOUTS
 function DeleteBlackoutsQuery($blackoutid){
+    Log::Debug('Deleting blackout with id %s', $blackoutid);
+
     $deleteBlackoutSeriesResources = new AdHocCommand(
         "   DELETE FROM blackout_series_resources
             WHERE blackout_series_id = '{$blackoutid}'"
@@ -222,4 +186,62 @@ function DeleteBlackoutsQuery($blackoutid){
     ServiceLocator::GetDatabase()->Execute($deleteBlackoutSeries);
 
     Log::Debug('Blackout with id %s deleted', $blackoutid);
+}
+
+//          ->    RESERVATION USERS
+function DeleteReservationUsersQuery($reservationInstanceId){
+    $deleteReservationGuests = new AdHocCommand(
+        "DELETE FROM reservation_guests
+        WHERE reservation_instance_id = '{$reservationInstanceId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationGuests);
+
+    $deleteReservationUsers = new AdHocCommand(
+        "DELETE FROM reservation_users
+        WHERE reservation_instance_id = '{$reservationInstanceId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationUsers);
+}
+
+//          ->    RESERVATIONS
+function DeleteReservationsQuery($reservationId){
+    Log::Debug('Deleting reservation with id %s', $reservationId);
+
+    $deleteReservationAcessories = new AdHocCommand(
+        "DELETE FROM reservation_accessories
+        WHERE series_id = '{$reservationId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationAcessories);
+
+    $deleteReservationFiles = new AdHocCommand(
+        "DELETE FROM reservation_files
+        WHERE series_id = '{$reservationId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationFiles);
+
+    $deleteReservationReminders = new AdHocCommand(
+        "DELETE FROM reservation_reminders 
+        WHERE series_id = '{$reservationId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationReminders);
+
+    $deleteReservationResources = new AdHocCommand(
+        "DELETE FROM reservation_resources
+        WHERE series_id = '{$reservationId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationResources);
+
+    $deleteReservationInstances = new AdHocCommand(
+        "DELETE FROM reservation_instances
+        WHERE series_id = '{$reservationId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationInstances);
+
+    $deleteReservationSeries = new AdHocCommand(
+        "DELETE FROM reservation_series
+        WHERE series_id = '{$reservationId}'"
+    );    
+    ServiceLocator::GetDatabase()->Execute($deleteReservationSeries);
+
+    Log::Debug('Reservation with id %s deleted', $reservationId);
 }

--- a/Jobs/deleteolddata.php
+++ b/Jobs/deleteolddata.php
@@ -1,0 +1,225 @@
+<?php
+// // cleanup_script.php
+
+// // Your PHP logic goes here
+// $message = "Cron job executed successfully!\n";
+// $currentDateTime = date('Y-m-d H:i:s');
+// echo 'PROJECT -> '. $currentDateTime . ': ' .$message;
+
+/**
+*  Cron Example:
+*  This script must be executed at a specific time to be enabled
+*  * * * * * /usr/bin/env php -f ${WWW_DIR}/librebooking/Jobs/sendmissedcheckin.php
+
+*  Each * correspods to Minute Hour Day_Of_Month Month Day_Of_Week, respectively
+
+*  /usr/bin/env php -f                                  -> the path to php (run "which php" to know where it is)
+*  ${WWW_DIR}/librebooking/Jobs/sendmissedcheckin.php   -> the path to this script
+*/
+define('ROOT_DIR', dirname(__FILE__) . '/../');
+require_once(ROOT_DIR . 'Domain/Access/namespace.php');
+require_once(ROOT_DIR . 'Jobs/JobCop.php');
+
+Log::Debug('Running deleteolddata.php');
+
+$configFilePath = '/opt/lampp/htdocs/librebooking/app/config/config.php';
+
+if (file_exists($configFilePath)) { echo ("Ficheiro existe!"); } 
+
+JobCop::EnsureCommandLine();
+
+try {
+    //ANNOUNCEMENTS
+    $getAnnouncements = GetAnnoucementsIdsToDeleteQuery();
+    echo $getAnnouncements;
+    $reader = ServiceLocator::GetDatabase()->Query($getAnnouncements);
+    Log::Debug('Getting %s old announcements', $reader->NumRows());
+    while ($row = $reader->GetRow()) {
+        $annoucementId = $row[ColumnNames::ANNOUNCEMENT_ID];
+        Log::Debug('Deleting announcement with id %s', $annoucementId);
+        DeleteAnnouncementsQuery($AnnoucementId);
+    }
+    $reader->Free();
+
+    //BLACKOUTS
+    $getBlackouts = GetBlackoutsIdsToDeleteQuery();
+    echo $getBlackouts;
+    $reader = ServiceLocator::GetDatabase()->Query($getBlackouts);
+    Log::Debug('Getting %s old blackouts', $reader->NumRows());
+    while ($row = $reader->GetRow()) {
+        $blackoutId = $row[ColumnNames::BLACKOUT_SERIES_ID];
+        Log::Debug('Deleting blackout with id %s', $blackoutId);
+        DeleteBlackoutsQuery($BlackoutId);      
+    }
+    $reader->Free();
+
+    //RESERVATIONS
+    $getReservations = GetReservationsIdsToDeleteQuery();
+    echo $getReservations;
+    $reader = ServiceLocator::GetDatabase()->Query($getReservations);
+    Log::Debug('Getting %s old reservations', $reader->NumRows());
+    while ($row = $reader->GetRow()) {
+        $reservationId = $row[ColumnNames::RESERVATION_SERIES_ID];
+        Log::Debug('Deleting reservation with id %s', $reservationId);
+        DeleteReservationsQuery($ReservationId);
+    }
+    $reader->Free();
+    
+
+} catch (Exception $ex){
+    Log::Error('Error running deleteolddata.php: %s', $ex);
+}
+
+Log::Debug('Finished running deleteolddata.php');
+
+
+function GetReservationsIdsToDeleteQuery() {
+    
+    $deleteBefore = Date::Now()->AddYears(-1);
+
+    $reservationIds = new AdHocCommand(
+        "   SELECT reservation_series.series_id
+            FROM reservation_series
+            LEFT JOIN reservation_instances 
+            ON reservation_instances.series_id = reservation_series.series_id
+            WHERE reservation_series.repeat_type = 'none' AND end_date < '{$deleteBefore}'
+            
+            UNION
+            
+            SELECT series_id
+            FROM reservation_series
+            WHERE SUBSTRING_INDEX(SUBSTRING_INDEX(repeat_options, '|', -1), '=', -1) < '{$deleteBefore}' AND repeat_options != ''"
+    );
+
+    return $reservationIds;
+}
+
+function GetAnnoucementsIdsToDeleteQuery(){
+
+    $deleteBefore = Date::Now()->AddYears(-1);
+
+    $annoucementsIds = new AdHocCommand(
+        "   SELECT announcementid
+            FROM announcements
+            WHERE end_date < '{$deleteBefore}'"
+    );
+
+    return $annoucementsIds;
+}
+
+function GetBlackoutsIdsToDeleteQuery(){
+
+    $deleteBefore = Date::Now()->AddYears(-1);
+
+    $blackoutsIds = new AdHocCommand(
+        "   SELECT blackout_series_id
+            FROM blackout_series
+            WHERE SUBSTRING_INDEX(SUBSTRING_INDEX(SUBSTRING_INDEX(repeat_options, '|', -2),'=',-2),'|',1) < '{$deleteBefore}' AND repeat_options != ''
+            
+            UNION
+            
+            SELECT blackout_series.blackout_series_id
+            FROM blackout_series
+            LEFT JOIN blackout_instances
+            ON blackout_series.blackout_series_id = blackout_instances.blackout_series_id
+            WHERE blackout_series.repeat_type = 'none' AND blackout_instances.end_date < '{$deleteBefore}'"
+    );
+
+    return $blackoutsIds;
+}
+
+function DeleteReservationsQuery($reservationId){
+    $deleteReservationAcessories = new AdHocCommand(
+        "DELETE FROM reservation_acessories
+        WHERE series_id = '{$reservationId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationAcessories);
+
+    $deleteReservationFiles = new AdHocCommand(
+        "DELETE FROM reservation_files
+        WHERE series_id = '{$reservationId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationFiles);
+
+    $deleteReservationGuests = new AdHocCommand(
+        "DELETE FROM reservation_guests
+        WHERE series_id = '{$reservationId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationGuests);
+
+    $deleteReservationReminders = new AdHocCommand(
+        "DELETE FROM reservation_reminders 
+        WHERE series_id = '{$reservationId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationReminders);
+
+    $deleteReservationResources = new AdHocCommand(
+        "DELETE FROM reservation_resources
+        WHERE series_id = '{$reservationId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationResources);
+
+    $deleteReservationUsers = new AdHocCommand(
+        "DELETE FROM reservation_users
+        WHERE series_id = '{$reservationId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationUsers);
+
+    $deleteReservationInstances = new AdHocCommand(
+        "DELETE FROM reservation_instances
+        WHERE series_id = '{$reservationId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationInstances);
+
+    $deleteReservationSeries = new AdHocCommand(
+        "DELETE FROM reservation_series
+        WHERE series_id = '{$reservationId}'"
+    );    
+    ServiceLocator::GetDatabase()->Execute($deleteReservationSeries);
+
+    Log::Debug('Reservation with id %s deleted', $reservationId);
+}
+
+function DeleteAnnouncementsQuery($announcementid){
+    $deleteGroupAnnouncements = new AdHocCommand(
+        "   DELETE FROM announcement_groups 
+            WHERE announcementid = '{$announcementid}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteGroupAnnouncements);
+
+    $deleteResourceAnnouncements = new AdHocCommand(
+        "   DELETE FROM announcement_resources 
+            WHERE announcementid = '{$announcementid}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteResourceAnnouncements);
+
+    $deleteAnnouncements = new AdHocCommand(
+        "   DELETE FROM announcements
+            WHERE announcementid = '{$announcementid}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteAnnouncements);
+
+    Log::Debug('Announcement with id %s deleted', $announcementid);
+}
+
+function DeleteBlackoutsQuery($blackoutid){
+    $deleteBlackoutSeriesResources = new AdHocCommand(
+        "   DELETE FROM blackout_series_resources
+            WHERE blackout_series_id = '{$blackoutid}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteBlackoutSeriesResources);
+
+    $deleteBlackoutInstances = new AdHocCommand(
+        "   DELETE FROM blackout_instances
+            WHERE blackout_series_id = '{$blackoutid}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteBlackoutInstances);
+
+    $deleteBlackoutSeries = new AdHocCommand(
+        "   DELETE FROM blackout_series
+            WHERE blackout_series_id = '{$blackoutid}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteBlackoutSeries);
+
+    Log::Debug('Blackout with id %s deleted', $blackoutid);
+}

--- a/Pages/LoginPage.php
+++ b/Pages/LoginPage.php
@@ -301,7 +301,7 @@ class LoginPage extends Page implements ILoginPage
      * Sends the created google url in the presenter to the smarty page 
      */
     public function SetGoogleUrl($googleUrl){
-        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_GOOGLE) == 'true'){
+        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_GOOGLE, new BooleanConverter())){
             $this->Set('GoogleUrl',$googleUrl);
         }
     }
@@ -310,7 +310,7 @@ class LoginPage extends Page implements ILoginPage
      * Sends the created microsoft url in the presenter to the smarty page 
      */
     public function SetMicrosoftUrl($microsoftUrl){
-        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_MICROSOFT) == 'true'){
+        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_MICROSOFT, new BooleanConverter())){
             $this->Set('MicrosoftUrl',$microsoftUrl);
         }
     }
@@ -319,7 +319,7 @@ class LoginPage extends Page implements ILoginPage
      * Sends the created facebook url in the presenter to the smarty page 
      */
     public function SetFacebookUrl($FacebookUrl){
-        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_FACEBOOK) == 'true'){
+        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_FACEBOOK, new BooleanConverter())){
             $this->Set('FacebookUrl',$FacebookUrl);
         }
     }

--- a/Presenters/Admin/ManageResourceGroupsPresenter.php
+++ b/Presenters/Admin/ManageResourceGroupsPresenter.php
@@ -120,7 +120,7 @@ class ManageResourceGroupsPresenter extends ActionPresenter
     {
         $nodeId = $this->page->GetNodeId();
 
-        Log::Debug('Deleting resource group. NodeId=%s, NewName=%s', $nodeId);
+        Log::Debug('Deleting resource group. NodeId=%s', $nodeId);
 
         $this->resourceRepository->DeleteResourceGroup($nodeId);
     }

--- a/Presenters/LoginPresenter.php
+++ b/Presenters/LoginPresenter.php
@@ -230,7 +230,7 @@ class LoginPresenter
      * Returns the created google url for the authentication  
      */
     public function GetGoogleUrl(){
-        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_GOOGLE) == 'true'){
+        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_GOOGLE, new BooleanConverter())){
             $client = new Google\Client();
             $client->setClientId(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::GOOGLE_CLIENT_ID));
             $client->setClientSecret(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::GOOGLE_CLIENT_SECRET));
@@ -249,7 +249,7 @@ class LoginPresenter
      * Returns the created microsoft url for the authentication  
      */
     public function GetMicrosoftUrl(){
-        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_MICROSOFT) == 'true'){
+        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_MICROSOFT, new BooleanConverter())){
             $MicrosoftUrl = 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize?'
                             .'client_id=' . urlencode(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::MICROSOFT_CLIENT_ID))
                             .'&redirect_uri=' . urlencode(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::MICROSOFT_REDIRECT_URI))
@@ -266,7 +266,7 @@ class LoginPresenter
      * Returns the created facebook url for the authentication  
      */
     public function GetFacebookUrl(){
-        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_FACEBOOK) == 'true'){
+        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_FACEBOOK, new BooleanConverter())){
             $facebook_Client = new Facebook\Facebook([
                             'app_id'                => Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::FACEBOOK_CLIENT_ID),
                             'app_secret'            => Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::FACEBOOK_CLIENT_SECRET),

--- a/config/config.devel.php
+++ b/config/config.devel.php
@@ -169,7 +169,7 @@ $conf['settings']['reservation.labels']['reservation.popup'] = ''; // Format for
  * Security header settings
  */
 $conf['settings']['security']['security.headers'] = 'false'; // Enable the following options
-$conf['settings']['security']['security.strict-transport'] = 'true';
+$conf['settings']['security']['security.strict-transport'] = 'max-age=31536000';
 $conf['settings']['security']['security.x-frame'] = 'deny';
 $conf['settings']['security']['security.x-xss'] = '1; mode=block';
 $conf['settings']['security']['security.x-content-type'] = 'nosniff';

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -169,7 +169,7 @@ $conf['settings']['reservation.labels']['reservation.popup'] = ''; // Format for
  * Security header settings
  */
 $conf['settings']['security']['security.headers'] = 'false'; // Enable the following options
-$conf['settings']['security']['security.strict-transport'] = 'true';
+$conf['settings']['security']['security.strict-transport'] = 'max-age=31536000';
 $conf['settings']['security']['security.x-frame'] = 'deny';
 $conf['settings']['security']['security.x-xss'] = '1; mode=block';
 $conf['settings']['security']['security.x-content-type'] = 'nosniff';

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -232,3 +232,11 @@ $conf['settings']['authentication']['microsoft.redirect.uri'] = '/Web/microsoft-
 $conf['settings']['authentication']['facebook.client.id'] = '';
 $conf['settings']['authentication']['facebook.client.secret'] = '';
 $conf['settings']['authentication']['facebook.redirect.uri'] = '/Web/facebook-auth.php';
+/**
+ *  Delete old data job configuration
+ *  Activate the deleteolddata.php as a background job to use this feature
+ */
+$conf['settings']['delete.old.data']['years.old.data'] = '3';               //Choose how long a blackout, announcement and reservation stay in the database (in years) counting from the end date
+$conf['settings']['delete.old.data']['delete.old.announcements'] = 'false'; //Choose if this feature deletes old announcements from database
+$conf['settings']['delete.old.data']['delete.old.blackouts'] = 'false';     //Choose if this feature deletes old blackouts from database
+$conf['settings']['delete.old.data']['delete.old.reservations'] = 'false';  //Choose if this feature deletes old reservations from database

--- a/lib/Application/Authentication/Registration.php
+++ b/lib/Application/Authentication/Registration.php
@@ -188,6 +188,8 @@ class Registration implements IRegistration
         $groupsToSync = [];
         if ($userGroups != null) {
             $lowercaseGroups = array_map('strtolower', $userGroups);
+            $altGroups = $userGroups;
+            $altGroups= array_map(function($dn) {return sscanf(explode(",", $dn)[0], "cn=%s,")[0];}, $altGroups);
 
             $groupsToSync = [];
             $groups = $this->groupRepository->GetList()->Results();
@@ -197,7 +199,12 @@ class Registration implements IRegistration
                     Log::Debug('Syncing group %s for user %s', $group->Name(), $user->Username());
                     $groupsToSync[] = new UserGroup($group->Id(), $group->Name());
                 } else {
-                    Log::Debug('User %s is not part of group %s, sync skipped', $user->Username(), $group->Name());
+                    if (in_array(strtolower($group->Name()), $altGroups)) {
+                      Log::Debug('Syncing group %s for user %s', $group->Name(), $user->Username());
+                      $groupsToSync[] = new UserGroup($group->Id(), $group->Name());
+                    } else {
+                      Log::Debug('User %s is not part of group %s, sync skipped', $user->Username(), $group->Name());
+                    }
                 }
             }
         }

--- a/lib/Common/Logging/Log.php
+++ b/lib/Common/Logging/Log.php
@@ -35,11 +35,18 @@ class Log
         if ($log_level != 'none') {
             $log_folder = Configuration::Instance()->GetSectionKey(ConfigSection::LOGGING, ConfigKeys::LOGGING_FOLDER);
             $log_sql = Configuration::Instance()->GetSectionKey(ConfigSection::LOGGING, ConfigKeys::LOGGING_SQL, new BooleanConverter());
-            $this->logger->pushHandler(new StreamHandler($log_folder.'/app.log', Logger::DEBUG));
-        }
-            if ($log_sql) {
-                $this->sqlLogger->pushHandler(new StreamHandler($log_folder.'/sql.log', Logger::DEBUG));
+            switch ($log_level) {
+                case 'debug':
+                    $this->logger->pushHandler(new StreamHandler($log_folder.'/app.log', Logger::DEBUG));
+                    break;
+                case 'error':
+                    $this->logger->pushHandler(new StreamHandler($log_folder.'/app.log', Logger::ERROR));
+                    break;
             }
+        }
+        if ($log_sql) {
+            $this->sqlLogger->pushHandler(new StreamHandler($log_folder.'/sql.log', Logger::ERROR));
+        }
     }
 
     /**
@@ -61,7 +68,7 @@ class Log
     public static function Debug($message, $args = [])
     {
         $log_level = Configuration::Instance()->GetSectionKey(ConfigSection::LOGGING, ConfigKeys::LOGGING_LEVEL);
-        if ($log_level == 'none' || $log_level == 'error') {
+        if ($log_level == 'none') {
             return;
         }
 
@@ -79,7 +86,7 @@ class Log
 
             $log = '[User=' . ServiceLocator::GetServer()->GetUserSession() . '] ' . $log;
 
-            self::GetInstance()->logger->info($log);
+            self::GetInstance()->logger->debug($log);
         } catch (Exception $ex) {
             echo $ex;
         }
@@ -92,7 +99,7 @@ class Log
     public static function Error($message, $args = [])
     {
         $log_level = Configuration::Instance()->GetSectionKey(ConfigSection::LOGGING, ConfigKeys::LOGGING_LEVEL);
-        if ($log_level == 'none' || $log_level == 'debug') {
+        if ($log_level == 'none') {
             return;
         }
 

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -172,6 +172,10 @@ class ConfigKeys
     public const FACEBOOK_CLIENT_SECRET = 'facebook.client.secret';
     public const FACEBOOK_REDIRECT_URI = 'facebook.redirect.uri';
 
+    public const YEARS_OLD_DATA = 'years.old.data';
+    public const DELETE_OLD_ANNOUNCEMENTS = 'delete.old.announcements'; 
+    public const DELETE_OLD_BLACKOUTS = 'delete.old.blackouts'; 
+    public const DELETE_OLD_RESERVATIONS = 'delete.old.reservations'; 
 }
 
 class ConfigSection
@@ -201,4 +205,5 @@ class ConfigSection
     public const TABLET_VIEW = 'tablet.view';
     public const REGISTRATION = 'registration';
     public const LOGGING = 'logging';
+    public const DELETE_OLD_DATA = 'delete.old.data';
 }


### PR DESCRIPTION
Script can be used as a chron job to delete announcements, blackouts and reservations older than x years, regularly. How old the data to delete is can be set in the config file